### PR TITLE
[Feature #161581453] Add order details page

### DIFF
--- a/UI/html/made_order.html
+++ b/UI/html/made_order.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="eng">
+  <head>
+    <meta charset="utf-8">
+    <title>Made Order</title>
+    <link rel="stylesheet"  href="../css/styles.css">
+  </head>
+  <body>
+    <div class="header">
+
+
+          <nav>
+            <ul>
+              <a href=""><img src="../img/delivery-logo.jpg"></a>
+              <li><a href="login.html">Log Out</a></li>
+              <li><a href="#">Profile</a></li>
+              <li><a href="#"></a></li>
+              <li><a href="">Home</a></li>
+            </ul>
+          </nav>
+
+
+    </div>
+
+    <div class="main-body">
+      <div class="main-body-text">
+        <h2>Parcel order details</h2>
+         <div class="parcel-section">
+          <form method="post" action="see_details.html">
+                  <table id="orders">
+                <th>Order Date</th>
+                <th>Order No</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Price</th>
+              </tr>
+              <tr>
+                <td>#</td>
+                <td>1</td>
+                <td>Nairobi</td>
+                <td>Nakuru</td>
+                <td>Sh.</td>
+              </tr>
+              <tr>
+                <td>#</td>
+                <td>2</td>
+                <td>Kisumu</td>
+                <td>Kitale</td>
+                <td>Sh.</td>
+              </tr>
+            </table><br><br>
+
+              <button>
+                <a href="cancel_delivery.html">Cancel Delivery</a>
+              </button>
+              <button>
+                <a href="change_destination.html">Change Destination</a>
+              </button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+      <!-- </div> -->
+    <div class="footer">
+      <p>SendIT - Couriers @ 2018</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
**What does this PR do?**
Add a page where delivery order details can be viewed

**Description of task to be completed?**
Create a parcel delivery order details page

**How should this be manually tested?**
Clone repository
https://github.com/OnyiegoAyub/SendIt-CH1
Cd to repository and checkout to the feature branch
git checkout ft-delivery-order-details-161581453
cd UI, cd html then open product_details.html in a browser

**What are the relevant pivotal tracker stories?**
#161581453

**Screenshots(if appropriate
![details](https://user-images.githubusercontent.com/38955236/47910134-e3a35300-dea2-11e8-89af-8f9b4658d64d.PNG)
